### PR TITLE
do not bundle dotnet

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -71,12 +71,6 @@ jobs:
           dotnet publish ${{ env.PROJECT_FOLDER}}/${{ env.PROJECT_NAME }} \
           -c ${{ env.CONFIGURATION }} \
           -r ${{ matrix.rid }} \
-          -p:PublishSingleFile=true \
-          -p:IncludeNativeLibrariesForSelfExtract=true \
-          -p:IncludeAllContentForSelfExtract=true \
-          -p:SelfContained=true \
-          -p:EnableCompressionInSingleFile=true \
-          -p:DebugType=embedded \
           -p:Version=${{ steps.gitversion.outputs.SemVer }} \
           -p:AssemblyVersion=${{ steps.gitversion.outputs.AssemblySemFileVer }} \
           -o bin

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -81,7 +81,7 @@ jobs:
         
       - name: Tar to Preserve Executable Bit
         if: ${{ startsWith(matrix.rid, 'osx') }}
-        run: tar -C bin -cvf ${{ env.APP_NAME }}.${{ steps.gitversion.outputs.semVer }}+${{ matrix.rid }}.tar ${{ env.APP_NAME }}
+        run: tar -cvf ${{ env.APP_NAME }}.${{ steps.gitversion.outputs.semVer }}+${{ matrix.rid }}.tar bin/
 
       - name: Upload build artifacts
         if: ${{ startsWith(matrix.rid, 'osx') }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ This is an attempt at a cross-platform clone of X-Mouse-Button-Control.
 2. Extract the archive
 3. Run YMouseButtonControl
 
+## Requirements
+
+* [.NET 8.0 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+  * On windows if you run YMouseButtonControl.exe, it will take you to the download automatically
+
+### Linux
+
+*Ubuntu*: ```sudo apt install dotnet-runtime-8.0```
+
+*Fedora*: ```sudo dnf install dotnet-runtime-8.0```
+
+*Arch*: ```sudo pacman -S dotnet-runtime```
+
 ## OS Compatibility
 
 Anything that can install .NET 8 should be able to run YMouseButtonControl
@@ -46,12 +59,6 @@ Anything that can install .NET 8 should be able to run YMouseButtonControl
    dotnet publish YMouseButtonControl/YMouseButtonControl.csproj \
     -c Release \
     -r YOUR_PLATFORM \
-    --self-contained true \
-    -p:PublishSingleFile=true \
-    -p:DebugType=embedded \
-    -p:IncludeNativeLibrariesForSelfExtract=true \
-    -p:IncludeAllContentForSelfExtract=true \
-    -p:EnableCompressionInSingleFile=true \
     -o bin
    ```
     * YOUR_PLATFORM: win-x64, linux-x64, osx-x64, [more runtimes here](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)


### PR DESCRIPTION
* Do not bundle dotnet runtime
* Do not create package everything in a single executable

The reason is I'm targeting an audience that is capable of installing .net 8.0 runtime themselves, it will improve startup performance, and decrease download size 